### PR TITLE
DRILL-5172: Display elapsed time for queries in the UI

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileWrapper.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/server/rest/profile/ProfileWrapper.java
@@ -114,6 +114,10 @@ public class ProfileWrapper {
     return profile;
   }
 
+  public String getProfileDuration() {
+    return ProfileResources.getPrettyDuration(profile.getStart(), profile.getEnd());
+  }
+
   public String getQueryId() {
     return id;
   }

--- a/exec/java-exec/src/main/resources/rest/profile/list.ftl
+++ b/exec/java-exec/src/main/resources/rest/profile/list.ftl
@@ -36,6 +36,7 @@
            <td>User</td>
            <td>Query</td>
            <td>State</td>
+           <td>Elapsed</td>
            <td>Foreman</td>
         </thead>
         <tbody>
@@ -62,7 +63,9 @@
               </a>
             </td> 
             <td>
-              <div style="height:100%;width:100%">${query.getState()}</div>          
+              <div style="height:100%;width:100%">${query.getState()}</div>
+            <td>
+              <div style="height:100%;width:100%">${query.getDuration()}</div>
             <td>
                 <div style="height:100%;width:100%">
                   ${query.getForeman()}
@@ -91,6 +94,7 @@
          <!-- <td>Query Id</td> -->
          <td>Query</td>
          <td>State</td>
+         <td>Duration</td>
          <td>Foreman</td>
       </thead>
       <tbody>
@@ -119,6 +123,9 @@
           </td>      
           <td>
               <div style="height:100%;width:100%">${query.getState()}</div>
+          </td>
+          <td>
+              <div style="height:100%;width:100%">${query.getDuration()}</div>
           </td>
           <td>
               <div style="height:100%;width:100%">

--- a/exec/java-exec/src/main/resources/rest/profile/profile.ftl
+++ b/exec/java-exec/src/main/resources/rest/profile/profile.ftl
@@ -106,6 +106,7 @@
   <p>STATE: ${model.getProfile().getState().name()}</p>
   <p>FOREMAN: ${model.getProfile().getForeman().getAddress()}</p>
   <p>TOTAL FRAGMENTS: ${model.getProfile().getTotalFragments()}</p>
+  <p>DURATION: ${model.getProfileDuration()}</p>
 
   <#assign options = model.getOptions()>
   <#if (options?keys?size > 0)>


### PR DESCRIPTION
Displays the elapsed time for running queries and the total duration of completed/failed/cancelled queries in the list of query profiles displayed, and within a query's profile page as well.
The query runtime is  displayed in '[hr] [min] sec'.
e.g. A duration of 25,254,321ms is displayed  7 hr 00 min 54.321 sec